### PR TITLE
Initial Benchmark commit.

### DIFF
--- a/src/Akka.Serialization.Benchmarks/Akka.Serialization.Benchmarks.csproj
+++ b/src/Akka.Serialization.Benchmarks/Akka.Serialization.Benchmarks.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Akka" Version="1.5.15" />
+      <PackageReference Include="Akka.Serialization.Hyperion" Version="1.5.15" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="MessagePack" Version="2.5.140" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="Akka.Serialization.MessagePack">
+        <HintPath>..\..\..\Akka.Serialization.MessagePack\Akka.Serialization.MessagePack\bin\Release\net6.0\Akka.Serialization.MessagePack.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/src/Akka.Serialization.Benchmarks/Akka.Serialization.Benchmarks.sln
+++ b/src/Akka.Serialization.Benchmarks/Akka.Serialization.Benchmarks.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Serialization.Benchmarks", "Akka.Serialization.Benchmarks.csproj", "{4C8C9B04-1131-4C03-9858-6388821FCA0A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4C8C9B04-1131-4C03-9858-6388821FCA0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C8C9B04-1131-4C03-9858-6388821FCA0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C8C9B04-1131-4C03-9858-6388821FCA0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C8C9B04-1131-4C03-9858-6388821FCA0A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Akka.Serialization.Benchmarks/Program.cs
+++ b/src/Akka.Serialization.Benchmarks/Program.cs
@@ -1,0 +1,440 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Serialization;
+using Akka.Serialization.MessagePack;
+using Akka.Util;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Newtonsoft.Json;
+
+namespace SerializationBenchmarks
+{
+    public class SimpleActor : ReceiveActor
+    {
+        public SimpleActor()
+        {
+            
+        }
+    }
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //BenchmarkRunner.Run<MessagePackSerializerTests>();
+            BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly })
+                .RunAllJoined();
+        }
+    }
+
+    public class TestSer
+    {
+        public int Id { get; set; }
+        public string someStr { get; set; }
+        public string someStr2 { get; set; }
+        public string someStr3 { get; set; }
+        public Guid IDK { get; set; }
+    }
+
+    internal static class HelperExts
+    {
+        public static string GetManifest(this Serializer ser, object obj)
+        {
+            if (ser is SerializerWithStringManifest swsm)
+            {
+                return swsm.Manifest(obj);
+            }
+            else
+            {
+                return TypeExtensions.TypeQualifiedName(obj.GetType());
+;            }
+        }
+    }
+    public class TestSer_WithRef
+    {
+        public int Id { get; set; }
+        public string someStr { get; set; }
+        public string someStr2 { get; set; }
+        public string someStr3 { get; set; }
+        public Guid IDK { get; set; }
+        public IActorRef Ref { get; set; }
+    }
+
+    public class TestSer_Inheriting : TestSer
+    {
+        public string NewProp { get; set; }
+    }
+
+    public sealed class TestSer_Sealed
+    {
+        public string SomeValue { get; set; }
+    }
+
+    public class TestSer_Enclosed_Polymorphic_TestSerNoRef
+    {
+        public TestSer SomeValue { get; set; }
+    }
+    public class TestSer_Enclosed_Polymorphic_Object
+    {
+        public object Value { get; set; }
+    }
+
+    public class JsonSerializerTests : BaseSerializerTests
+    {
+        protected override string testSysName => "bench-serialization-json-nopool";
+
+        protected override Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>>
+            createSerializer => (eas) =>
+            ImmutableHashSet.Create( SerializerDetails.Create("json", new NewtonSoftJsonSerializer(eas),
+                ImmutableHashSet.Create(typeof(object))));
+    }
+    
+    public class HyperionSerializerTests : BaseSerializerTests
+    {
+        protected override string testSysName => "bench-serialization-hyperion";
+
+        protected override Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>>
+            createSerializer => (eas) =>
+            ImmutableHashSet.Create( SerializerDetails.Create("hyperion", new HyperionSerializer(eas),
+                ImmutableHashSet.Create(typeof(object))));
+    }
+    
+    public class MessagePackSerializerTests : BaseSerializerTests
+    {
+        protected override string testSysName => "bench-serialization-messagepack";
+
+        protected override Func<ExtendedActorSystem, ImmutableHashSet<SerializerDetails>>
+            createSerializer => (eas) =>
+            ImmutableHashSet.Create( SerializerDetails.Create("hyperion", new MsgPackSerializer(eas),
+                ImmutableHashSet.Create(typeof(object))));
+    }
+    
+    [MemoryDiagnoser]
+    public abstract class BaseSerializerTests
+    {
+        protected BaseSerializerTests()
+        {
+            var setup = BootstrapSetup.Create().And(
+                SerializationSetup.Create(createSerializer));
+            _sys_noPool = ActorSystem.Create(testSysName, setup);
+            _poolSer = 
+            _sys_noPool.Serialization.FindSerializerForType(typeof(object));
+            var aRef = _sys_noPool.ActorOf<SimpleActor>();
+            testObj_WithRef =  new()
+            {
+                Id = 124,
+                someStr =
+                    "412tgieoargj4a9349u2u-03jf3290rjf2390ja209fj1099u42n0f92qm93df3m-032jfq-102",
+                someStr2 =
+                    "412tgieoargj4a9349u2u-03jf3290rjf2390ja209fj1099u42n0f92qm93df3m-032jfq-102",
+                someStr3 =
+                    new string(Enumerable.Repeat('l',512).ToArray()),
+                IDK = Guid.Empty, Ref = aRef
+            };
+            _testObj_inheriting = new TestSer_Inheriting()
+            {
+                Id = 124,
+                someStr =
+                    "412tgieoargj4a9349u2u-03jf3290rjf2390ja209fj1099u42n0f92qm93df3m-032jfq-102",
+                someStr2 =
+                    "412tgieoargj4a9349u2u-03jf3290rjf2390ja209fj1099u42n0f92qm93df3m-032jfq-102",
+                someStr3 =
+                    new string(Enumerable.Repeat('l', 512).ToArray()),
+                IDK = Guid.Empty,
+                NewProp = "wat"
+            };
+            _testObj_sealed = new TestSer_Sealed()
+            {
+                SomeValue = "idk"
+            };
+            _testObj_poly = new TestSer_Enclosed_Polymorphic_Object(){Value = testObj};
+            _testObj_poly_inherited =
+                new TestSer_Enclosed_Polymorphic_TestSerNoRef()
+                    { SomeValue = testObj };
+            _binaryRep_noRef = _poolSer.ToBinary(testObj);
+            _binaryRep_withRef = _poolSer.ToBinary(testObj_WithRef);
+            _binaryRep_manifest = _poolSer.IncludeManifest
+                ? _poolSer.GetManifest(testObj) : string.Empty;
+            _binaryRep_withRef_manifest = _poolSer.IncludeManifest?
+                _poolSer.GetManifest(testObj_WithRef) : string.Empty;
+            _binaryRep_inheriting = _poolSer.ToBinary(_testObj_inheriting);
+            _binaryRep_inheriting_manifest = _poolSer.IncludeManifest?
+                _poolSer.GetManifest(_testObj_inheriting) : string.Empty;
+            _binaryRep_sealed = _poolSer.ToBinary(_testObj_sealed);
+            _binaryRep_sealed_manifest = _poolSer.IncludeManifest?
+                _poolSer.GetManifest(_testObj_sealed) : string.Empty;
+            _binaryRep_poly = _poolSer.ToBinary(_testObj_poly);
+            _binaryRep_poly_manifest = _poolSer.IncludeManifest?
+                _poolSer.GetManifest(_testObj_poly) : string.Empty;
+            _binaryRep_poly_inherited = _poolSer.ToBinary(_testObj_poly_inherited);
+            _binaryRep_poly_inherited_manifest = _poolSer.IncludeManifest?
+                _poolSer.GetManifest(_testObj_poly_inherited) : string.Empty;
+        }
+
+        protected abstract string testSysName { get; }
+
+        protected abstract Func<ExtendedActorSystem,
+                ImmutableHashSet<SerializerDetails>>
+            createSerializer { get; }
+
+        private static TestSer testObj = new()
+        {
+            Id = 124,
+            someStr =
+                "412tgieoargj4a9349u2u-03jf3290rjf2390ja209fj1099u42n0f92qm93df3m-032jfq-102",
+            someStr2 =
+                "412tgieoargj4a9349u2u-03jf3290rjf2390ja209fj1099u42n0f92qm93df3m-032jfq-102",
+            someStr3 =
+                new string(Enumerable.Repeat('l',512).ToArray()),
+            IDK = Guid.Empty
+        };
+
+        private readonly TestSer_WithRef testObj_WithRef;
+
+        private ActorSystem _sys_noPool;
+        private Serializer _poolSer;
+        private readonly TestSer_Inheriting _testObj_inheriting;
+        private readonly TestSer_Sealed _testObj_sealed;
+        private readonly string _binaryRep_sealed_manifest;
+        private readonly string _binaryRep_inheriting_manifest;
+        private readonly byte[] _binaryRep_sealed;
+        private readonly byte[] _binaryRep_inheriting;
+        private readonly string _binaryRep_withRef_manifest;
+        private readonly string _binaryRep_manifest;
+        private readonly byte[] _binaryRep_withRef;
+        private readonly byte[] _binaryRep_noRef;
+        private readonly TestSer_Enclosed_Polymorphic_Object _testObj_poly;
+        private readonly TestSer_Enclosed_Polymorphic_TestSerNoRef _testObj_poly_inherited;
+        private readonly byte[] _binaryRep_poly;
+        private readonly string _binaryRep_poly_manifest;
+        private readonly byte[] _binaryRep_poly_inherited;
+        private readonly string _binaryRep_poly_inherited_manifest;
+
+        private const int _numIters = 10000; 
+        
+        private void Serialize(int wat)
+        {
+            for (int i = 0; i < _numIters; i++)
+            {
+                switch (wat)
+                {
+                    case 0:
+                    _poolSer.ToBinary(testObj);
+                    break;
+                    case 1:
+                        _poolSer.ToBinary(testObj_WithRef);
+                        break;
+                    case 2:
+                        _poolSer.ToBinary(_testObj_inheriting);
+                        break;
+                    case 3:
+                        _poolSer.ToBinary(_testObj_sealed);
+                        break;
+                    case 4:
+                        _poolSer.ToBinary(_testObj_poly);
+                        break;
+                    case 5:
+                        _poolSer.ToBinary(_testObj_poly_inherited);
+                        break;
+                }
+            }
+        }
+        
+        private void DeSerialize(int wat)
+        {
+            byte[] _bR = null;
+            string manifest = string.Empty;
+            Type _t = default;
+            switch (wat)
+            {
+                case 0:
+                    _bR = _binaryRep_noRef;
+                    manifest = _binaryRep_manifest;
+                    _t = typeof(TestSer);
+                    break;
+                case 1:
+                    _bR = _binaryRep_withRef;
+                    manifest = _binaryRep_withRef_manifest;
+                    _t = typeof(TestSer_WithRef);
+                    break;
+                case 2:
+                    _bR = _binaryRep_inheriting;
+                    manifest = _binaryRep_inheriting_manifest;
+                    _t = typeof(TestSer_Inheriting);
+                    break;
+                case 3:
+                    _bR = _binaryRep_sealed;
+                    manifest = _binaryRep_sealed_manifest;
+                    _t = typeof(TestSer_Sealed);
+                    break;
+                case 4:
+                    _bR = _binaryRep_poly;
+                    manifest = _binaryRep_poly_manifest;
+                    _t = typeof(TestSer_Enclosed_Polymorphic_Object);
+                    break;
+                case 5:
+                    _bR = _binaryRep_poly_inherited;
+                    manifest = _binaryRep_poly_inherited_manifest;
+                    _t = typeof(TestSer_Enclosed_Polymorphic_TestSerNoRef);
+                    break;
+            }
+            for (int i = 0; i < _numIters; i++)
+            {
+                if (_poolSer.IncludeManifest && _poolSer is SerializerWithStringManifest swsm)
+                {
+                        swsm.FromBinary(_bR, manifest);
+                }
+                else
+                {
+                    _poolSer.FromBinary(_bR,
+                        _t);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void Serialize_SimpleObj_NonSealed_NoRef()
+        {
+            Serialize(0);
+        }
+        [Benchmark]
+        public void Serialize_SimpleObj_NonSealed_WithRef()
+        {
+            Serialize(1);
+        }
+        
+        [Benchmark]
+        public void Serialize_SimpleObj_Inheriting_NoRef()
+        {
+            Serialize(2);
+        }
+        
+        [Benchmark]
+        public void Serialize_SimpleObj_Sealed_NoRef()
+        {
+            Serialize(3);
+        }
+        
+        [Benchmark]
+        public void SerializePoly_Object_NoRef()
+        {
+            Serialize(4);
+        }
+        [Benchmark]
+        public void SerializePoly_Inheriting_NoRef()
+        {
+            Serialize(5);
+        }
+        [Benchmark]
+        public void Serialize_MultiTask_SimpleObj_NonSealed_NoRef()
+        {
+            MultiTasks_Do(0);
+        }
+        [Benchmark]
+        public void Serialize_MultiTask_SimpleObj_NonSealed_WithRef()
+        {
+            MultiTasks_Do(1);
+        }
+        
+        [Benchmark]
+        public void Serialize_MultiTask_SimpleObj_Inheriting_NoRef()
+        {
+            MultiTasks_Do(2);
+        }
+        
+        [Benchmark]
+        public void Serialize_MultiTask_SimpleObj_Sealed_NoRef()
+        {
+            MultiTasks_Do(3);
+        }
+        [Benchmark]
+        public void Serialize_MultiTask_Poly_Object_NoRef()
+        {
+            MultiTasks_Do(4);
+        }
+        [Benchmark]
+        public void Serialize_MultiTask_Poly_Inheriting_NoRef()
+        {
+            MultiTasks_Do(5);
+        }
+        private void MultiTasks_Do(int wat)
+        {
+            Task.WaitAll(Enumerable.Repeat(wat,10)
+                .Select((i) => Task.Run(()=>Serialize(i))).ToArray());
+        }
+        
+        [Benchmark]
+        public void DeSerialize_SimpleObj_NonSealed_NoRef()
+        {
+            DeSerialize(0);
+        }
+        [Benchmark]
+        public void DeSerialize_SimpleObj_NonSealed_WithRef()
+        {
+            DeSerialize(1);
+        }
+        
+        [Benchmark]
+        public void DeSerialize_SimpleObj_Inheriting_NoRef()
+        {
+            DeSerialize(2);
+        }
+        
+        [Benchmark]
+        public void DeSerialize_SimpleObj_Sealed_NoRef()
+        {
+            DeSerialize(3);
+        }
+        
+        [Benchmark]
+        public void DeSerialize_Poly_Object_NoRef()
+        {
+            DeSerialize(4);
+        }
+        [Benchmark]
+        public void DeSerialize_Poly_Inherited_NoRef()
+        {
+            DeSerialize(5);
+        }
+        [Benchmark]
+        public void DeSerialize_MultiTask_SimpleObj_NonSealed_NoRef()
+        {
+            DeserializeMultiTasks_Do(0);
+        }
+        [Benchmark]
+        public void DeSerialize_MultiTask_SimpleObj_NonSealed_WithRef()
+        {
+            DeserializeMultiTasks_Do(1);
+        }
+        
+        [Benchmark]
+        public void DeSerialize_MultiTask_SimpleObj_Inheriting_NoRef()
+        {
+            DeserializeMultiTasks_Do(2);
+        }
+        
+        [Benchmark]
+        public void DeSerialize_MultiTask_SimpleObj_Sealed_NoRef()
+        {
+            DeserializeMultiTasks_Do(3);
+        }
+        private void DeserializeMultiTasks_Do(int wat)
+        {
+            Task.WaitAll(Enumerable.Repeat(wat,10)
+                .Select((i) => Task.Run(()=>DeSerialize(i))).ToArray());
+        }
+    }
+}


### PR DESCRIPTION
I'm not Unhappy 😁 

```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.3930/22H2/2022Update)
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
```

| Type                       | Method                                            | Mean            | Error         | StdDev          | Gen0       | Gen1      | Allocated  |
|--------------------------- |-------------------------------------------------- |----------------:|--------------:|----------------:|-----------:|----------:|-----------:|
| HyperionSerializerTests    | Serialize_SimpleObj_NonSealed_NoRef               |      1,412.4 ns |      28.21 ns |        28.97 ns |     0.8469 |    0.0057 |     3992 B |
| JsonSerializerTests        | Serialize_SimpleObj_NonSealed_NoRef               |      5,866.8 ns |      42.76 ns |        40.00 ns |     1.2054 |         - |     5705 B |
| MessagePackSerializerTests | Serialize_SimpleObj_NonSealed_NoRef               |        500.3 ns |       9.89 ns |         9.25 ns |     0.1631 |         - |      768 B |
| HyperionSerializerTests    | Serialize_SimpleObj_NonSealed_WithRef             |      2,204.9 ns |      25.55 ns |        21.34 ns |     1.3885 |    0.0153 |     6544 B |
| JsonSerializerTests        | Serialize_SimpleObj_NonSealed_WithRef             |      8,338.0 ns |      28.87 ns |        27.00 ns |     1.5564 |         - |     7345 B |
| MessagePackSerializerTests | Serialize_SimpleObj_NonSealed_WithRef             |        928.1 ns |      18.23 ns |        22.39 ns |     0.2222 |         - |     1048 B |
| HyperionSerializerTests    | Serialize_SimpleObj_Inheriting_NoRef              |      1,474.3 ns |      11.69 ns |        10.36 ns |     0.8583 |    0.0057 |     4040 B |
| JsonSerializerTests        | Serialize_SimpleObj_Inheriting_NoRef              |      7,634.3 ns |      53.28 ns |        49.84 ns |     1.3428 |         - |     6337 B |
| MessagePackSerializerTests | Serialize_SimpleObj_Inheriting_NoRef              |        558.4 ns |       7.80 ns |         6.92 ns |     0.1659 |         - |      784 B |
| HyperionSerializerTests    | Serialize_SimpleObj_Sealed_NoRef                  |        301.2 ns |       2.12 ns |         1.88 ns |     0.1869 |         - |      880 B |
| JsonSerializerTests        | Serialize_SimpleObj_Sealed_NoRef                  |      3,794.6 ns |      37.04 ns |        32.84 ns |     0.7019 |         - |     3320 B |
| MessagePackSerializerTests | Serialize_SimpleObj_Sealed_NoRef                  |        184.2 ns |       2.99 ns |         2.80 ns |     0.0083 |         - |       40 B |
| HyperionSerializerTests    | SerializePoly_Object_NoRef                        |      1,541.3 ns |      26.26 ns |        24.56 ns |     0.8850 |    0.0019 |     4168 B |
| JsonSerializerTests        | SerializePoly_Object_NoRef                        |      9,296.5 ns |      86.26 ns |        76.47 ns |     1.6479 |         - |     7761 B |
| MessagePackSerializerTests | SerializePoly_Object_NoRef                        |        864.3 ns |       7.72 ns |         6.45 ns |     0.1793 |         - |      848 B |
| HyperionSerializerTests    | SerializePoly_Inheriting_NoRef                    |      1,734.7 ns |      25.42 ns |        23.78 ns |     1.3275 |    0.0153 |     6248 B |
| JsonSerializerTests        | SerializePoly_Inheriting_NoRef                    |      8,973.8 ns |      69.77 ns |        61.85 ns |     1.6479 |         - |     7809 B |
| MessagePackSerializerTests | SerializePoly_Inheriting_NoRef                    |        556.0 ns |       5.59 ns |         5.23 ns |     0.1659 |         - |      784 B |
| HyperionSerializerTests    | Serialize_MultiTask_SimpleObj_NonSealed_NoRef     |  6,007,957.1 ns | 114,061.89 ns |   140,078.24 ns |  8679.6875 |  601.5625 | 39922070 B |
| JsonSerializerTests        | Serialize_MultiTask_SimpleObj_NonSealed_NoRef     | 17,673,496.7 ns | 311,164.23 ns |   275,838.99 ns | 12406.2500 |  531.2500 | 57055356 B |
| MessagePackSerializerTests | Serialize_MultiTask_SimpleObj_NonSealed_NoRef     |  1,598,010.4 ns |  19,779.13 ns |    18,501.41 ns |  1736.3281 |    5.8594 |  7682060 B |
| HyperionSerializerTests    | Serialize_MultiTask_SimpleObj_NonSealed_WithRef   | 11,568,968.3 ns | 227,105.73 ns |   261,535.30 ns | 17281.2500 | 2031.2500 | 65362085 B |
| JsonSerializerTests        | Serialize_MultiTask_SimpleObj_NonSealed_WithRef   | 24,872,742.1 ns | 464,652.43 ns |   388,005.82 ns | 17343.7500 |  531.2500 | 73485167 B |
| MessagePackSerializerTests | Serialize_MultiTask_SimpleObj_NonSealed_WithRef   |  2,947,365.0 ns |  31,284.64 ns |    27,733.02 ns |  2480.4688 |    3.9063 | 10482063 B |
| HyperionSerializerTests    | Serialize_MultiTask_SimpleObj_Inheriting_NoRef    |  6,222,095.6 ns | 118,521.05 ns |   105,065.82 ns |  8679.6875 |  601.5625 | 40402070 B |
| JsonSerializerTests        | Serialize_MultiTask_SimpleObj_Inheriting_NoRef    | 22,995,122.2 ns | 408,811.32 ns |   437,423.53 ns | 13906.2500 |  718.7500 | 63375986 B |
| MessagePackSerializerTests | Serialize_MultiTask_SimpleObj_Inheriting_NoRef    |  1,832,197.8 ns |  23,839.58 ns |    21,133.17 ns |  1736.3281 |    5.8594 |  7842060 B |
| HyperionSerializerTests    | Serialize_MultiTask_SimpleObj_Sealed_NoRef        |  1,424,068.7 ns |  27,416.22 ns |    30,473.05 ns |  1931.6406 |   54.6875 |  8802060 B |
| JsonSerializerTests        | Serialize_MultiTask_SimpleObj_Sealed_NoRef        | 12,075,424.9 ns | 157,122.85 ns |   146,972.81 ns |  7140.6250 |  312.5000 | 33212226 B |
| MessagePackSerializerTests | Serialize_MultiTask_SimpleObj_Sealed_NoRef        |    517,009.7 ns |   9,555.39 ns |     8,938.11 ns |    85.9375 |         - |   402057 B |
| HyperionSerializerTests    | Serialize_MultiTask_Poly_Object_NoRef             |  6,542,599.4 ns | 130,480.89 ns |   231,929.65 ns |  9257.8125 |  648.4375 | 41682070 B |
| JsonSerializerTests        | Serialize_MultiTask_Poly_Object_NoRef             | 27,515,066.6 ns | 546,138.82 ns | 1,175,621.43 ns | 17343.7500 |  593.7500 | 77621450 B |
| MessagePackSerializerTests | Serialize_MultiTask_Poly_Object_NoRef             |  6,276,980.8 ns | 165,304.86 ns |   482,202.04 ns |  1929.6875 |         - |  8482070 B |
| HyperionSerializerTests    | Serialize_MultiTask_Poly_Inheriting_NoRef         | 11,543,616.6 ns | 117,452.25 ns |   109,864.90 ns | 17156.2500 | 1890.6250 | 62482085 B |
| JsonSerializerTests        | Serialize_MultiTask_Poly_Inheriting_NoRef         | 28,180,968.4 ns | 560,474.47 ns |   905,061.79 ns | 17343.7500 |  625.0000 | 78103311 B |
| MessagePackSerializerTests | Serialize_MultiTask_Poly_Inheriting_NoRef         |  1,884,485.6 ns |  37,158.89 ns |    63,098.62 ns |  1736.3281 |    5.8594 |  7842060 B |
| HyperionSerializerTests    | DeSerialize_SimpleObj_NonSealed_NoRef             |      1,051.1 ns |       7.45 ns |         6.22 ns |     0.6676 |    0.0057 |     3144 B |
| JsonSerializerTests        | DeSerialize_SimpleObj_NonSealed_NoRef             |      5,888.2 ns |      91.67 ns |        85.74 ns |     1.7090 |    0.0381 |     8056 B |
| MessagePackSerializerTests | DeSerialize_SimpleObj_NonSealed_NoRef             |        864.2 ns |      16.74 ns |        19.28 ns |     0.3109 |    0.0010 |     1464 B |
| HyperionSerializerTests    | DeSerialize_SimpleObj_NonSealed_WithRef           |      2,349.0 ns |      18.23 ns |        15.22 ns |     0.9079 |    0.0076 |     4280 B |
| JsonSerializerTests        | DeSerialize_SimpleObj_NonSealed_WithRef           |      9,660.1 ns |     157.21 ns |       139.36 ns |     2.0294 |    0.0458 |     9576 B |
| MessagePackSerializerTests | DeSerialize_SimpleObj_NonSealed_WithRef           |      2,187.2 ns |      13.84 ns |        11.56 ns |     0.4807 |         - |     2272 B |
| HyperionSerializerTests    | DeSerialize_SimpleObj_Inheriting_NoRef            |      1,143.6 ns |      14.03 ns |        12.44 ns |     0.6886 |    0.0038 |     3248 B |
| JsonSerializerTests        | DeSerialize_SimpleObj_Inheriting_NoRef            |      6,600.5 ns |     127.17 ns |       130.59 ns |     1.7395 |    0.0153 |     8192 B |
| MessagePackSerializerTests | DeSerialize_SimpleObj_Inheriting_NoRef            |        932.4 ns |      12.48 ns |        11.67 ns |     0.3195 |    0.0010 |     1504 B |
| HyperionSerializerTests    | DeSerialize_SimpleObj_Sealed_NoRef                |        487.6 ns |       4.56 ns |         4.27 ns |     0.1717 |         - |      808 B |
| JsonSerializerTests        | DeSerialize_SimpleObj_Sealed_NoRef                |      2,120.2 ns |      34.08 ns |        31.87 ns |     0.8392 |    0.0076 |     3952 B |
| MessagePackSerializerTests | DeSerialize_SimpleObj_Sealed_NoRef                |        235.9 ns |       4.53 ns |         3.78 ns |     0.0114 |         - |       56 B |
| HyperionSerializerTests    | DeSerialize_Poly_Object_NoRef                     |      1,481.0 ns |      16.74 ns |        15.66 ns |     0.7439 |    0.0038 |     3504 B |
| JsonSerializerTests        | DeSerialize_Poly_Object_NoRef                     |      7,603.2 ns |      41.56 ns |        38.88 ns |     1.8768 |    0.0305 |     8848 B |
| MessagePackSerializerTests | DeSerialize_Poly_Object_NoRef                     |      1,167.1 ns |      18.06 ns |        16.90 ns |     0.3147 |         - |     1488 B |
| HyperionSerializerTests    | DeSerialize_Poly_Inherited_NoRef                  |      1,553.4 ns |      19.37 ns |        18.12 ns |     0.7458 |    0.0019 |     3512 B |
| JsonSerializerTests        | DeSerialize_Poly_Inherited_NoRef                  |     10,844.7 ns |      52.42 ns |        46.46 ns |     1.9684 |    0.0458 |     9305 B |
| MessagePackSerializerTests | DeSerialize_Poly_Inherited_NoRef                  |        930.5 ns |      14.96 ns |        13.26 ns |     0.3147 |         - |     1488 B |
| HyperionSerializerTests    | DeSerialize_MultiTask_SimpleObj_NonSealed_NoRef   |  4,923,511.8 ns |  96,147.80 ns |    98,736.71 ns |  6945.3125 |  500.0000 | 31442070 B |
| JsonSerializerTests        | DeSerialize_MultiTask_SimpleObj_NonSealed_NoRef   | 19,557,797.5 ns | 190,554.03 ns |   168,921.19 ns | 17343.7500 | 1687.5000 | 80562103 B |
| MessagePackSerializerTests | DeSerialize_MultiTask_SimpleObj_NonSealed_NoRef   |  3,590,504.1 ns |  71,599.28 ns |   183,536.33 ns |  3468.7500 |  152.3438 | 14642063 B |
| HyperionSerializerTests    | DeSerialize_MultiTask_SimpleObj_NonSealed_WithRef |  8,374,151.8 ns | 134,950.41 ns |   119,630.03 ns |  9265.6250 |  671.8750 | 42802085 B |
| JsonSerializerTests        | DeSerialize_MultiTask_SimpleObj_NonSealed_WithRef | 30,513,154.2 ns | 370,731.02 ns |   346,782.02 ns | 23125.0000 | 3312.5000 | 95762103 B |
| MessagePackSerializerTests | DeSerialize_MultiTask_SimpleObj_NonSealed_WithRef |  8,218,024.6 ns | 161,183.58 ns |   250,943.42 ns |  4953.1250 |  250.0000 | 22722087 B |
| HyperionSerializerTests    | DeSerialize_MultiTask_SimpleObj_Inheriting_NoRef  |  5,041,616.1 ns |  91,867.23 ns |   195,776.55 ns |  6945.3125 |  523.4375 | 32482070 B |
| JsonSerializerTests        | DeSerialize_MultiTask_SimpleObj_Inheriting_NoRef  | 23,351,899.7 ns | 459,740.40 ns |   491,917.08 ns | 17718.7500 | 2875.0000 | 81922103 B |
| MessagePackSerializerTests | DeSerialize_MultiTask_SimpleObj_Inheriting_NoRef  |  3,853,474.3 ns |  32,798.56 ns |    27,388.28 ns |  3468.7500 |  171.8750 | 15042063 B |
| HyperionSerializerTests    | DeSerialize_MultiTask_SimpleObj_Sealed_NoRef      |  1,710,688.0 ns |  17,488.01 ns |    16,358.30 ns |  1740.2344 |   41.0156 |  8082060 B |
| JsonSerializerTests        | DeSerialize_MultiTask_SimpleObj_Sealed_NoRef      |  8,218,944.0 ns | 140,864.71 ns |   117,628.41 ns |  8671.8750 |  859.3750 | 39522080 B |
| MessagePackSerializerTests | DeSerialize_MultiTask_SimpleObj_Sealed_NoRef      |    707,513.7 ns |   9,905.91 ns |     9,266.00 ns |   120.1172 |         - |   562058 B |

